### PR TITLE
Fix symbol handling, where the symbol name is not a {base}{quote} name concatenation, fixes #4

### DIFF
--- a/samples/BinanceCodeGenerator/Program.cs
+++ b/samples/BinanceCodeGenerator/Program.cs
@@ -57,8 +57,15 @@ namespace BinanceCodeGenerator
                 lines.Insert(index++, $"        // {group.First().QuoteAsset}");
 
                 foreach (var symbol in group)
-                { 
-                    lines.Insert(index++, $"        public static readonly Symbol {symbol.BaseAsset}_{symbol.QuoteAsset} = new Symbol(Asset.{symbol.BaseAsset}, Asset.{symbol.QuoteAsset}, {symbol.BaseMinQuantity}m, {symbol.BaseMaxQuantity}m, {symbol.QuoteIncrement}m);");
+                {
+                    if ($"{symbol.BaseAsset}{symbol.QuoteAsset}" == symbol.ToString())
+                    {
+                        lines.Insert(index++, $"        public static readonly Symbol {symbol.BaseAsset}_{symbol.QuoteAsset} = new Symbol(Asset.{symbol.BaseAsset}, Asset.{symbol.QuoteAsset}, {symbol.BaseMinQuantity}m, {symbol.BaseMaxQuantity}m, {symbol.QuoteIncrement}m);");
+                    }
+                    else
+                    {
+                        lines.Insert(index++, $"        public static readonly Symbol {symbol} = new Symbol(Asset.{symbol.BaseAsset}, Asset.{symbol.QuoteAsset}, {symbol.BaseMinQuantity}m, {symbol.BaseMaxQuantity}m, {symbol.QuoteIncrement}m, {symbol});");
+                    }
                 }
 
                 lines.Insert(index++, string.Empty);
@@ -70,7 +77,14 @@ namespace BinanceCodeGenerator
 
             foreach(var symbol in symbols)
             {
-                lines.Insert(index++, $"            {{ \"{symbol}\", {symbol.BaseAsset}_{symbol.QuoteAsset} }},");
+                if ($"{symbol.BaseAsset}{symbol.QuoteAsset}" == symbol.ToString())
+                {
+                    lines.Insert(index++, $"            {{ \"{symbol}\", {symbol.BaseAsset}_{symbol.QuoteAsset} }},");
+                }
+                else
+                {
+                    lines.Insert(index++, $"            {{ \"{symbol}\", {symbol}}},");
+                }
             }
 
             // Save the generated source code (replacing original).

--- a/samples/BinanceCodeGenerator/Symbol.template.cs
+++ b/samples/BinanceCodeGenerator/Symbol.template.cs
@@ -105,7 +105,8 @@ namespace Binance
         /// <param name="baseMaxQty">The base asset maximum quantity.</param>
         /// <param name="baseMinQty">The base asset minimum quantity.</param>
         /// <param name="quoteIncrement">The quote asset increment price.</param>
-        public Symbol(Asset baseAsset, Asset quoteAsset, decimal baseMinQty, decimal baseMaxQty, decimal quoteIncrement)
+        /// <param name="symbolName">Symbol name override if it does not match with concatenated name of base and quote assets.</param>
+        public Symbol(Asset baseAsset, Asset quoteAsset, decimal baseMinQty, decimal baseMaxQty, decimal quoteIncrement, string symbolName = null)
         {
             Throw.IfNull(baseAsset, nameof(baseAsset));
             Throw.IfNull(quoteAsset, nameof(quoteAsset));
@@ -123,7 +124,14 @@ namespace Binance
             BaseMaxQuantity = baseMaxQty;
             QuoteIncrement = quoteIncrement;
 
-            _symbol = $"{baseAsset}{quoteAsset}";
+            if (!String.IsNullOrWhiteSpace(symbolName))
+            {
+                _symbol = symbolName;
+            }
+            else
+            {
+                _symbol = $"{baseAsset}{quoteAsset}";
+            }
         }
 
         #endregion Constructors

--- a/src/Binance/Api/BinanceApi.cs
+++ b/src/Binance/Api/BinanceApi.cs
@@ -330,12 +330,9 @@ namespace Binance.Api
 
                             var quoteIncrement = filters[0]["minPrice"].Value<decimal>();
 
-                            var symbol = new Symbol(baseAsset, quoteAsset, baseMinQty, baseMaxQty, quoteIncrement);
+                            var symbolName = $"{baseAsset}{quoteAsset}" != jToken["symbol"].Value<string>() ? jToken["symbol"].Value<string>() : null;
 
-                            if (symbol.ToString() != jToken["symbol"].Value<string>())
-                            {
-                                throw new BinanceApiException($"Symbol does not match assets ({jToken["symbol"].Value<string>()} != {symbol}).");
-                            }
+                            var symbol = new Symbol(baseAsset, quoteAsset, baseMinQty, baseMaxQty, quoteIncrement, symbolName);
 
                             return symbol;
                         }));

--- a/src/Binance/Asset.cs
+++ b/src/Binance/Asset.cs
@@ -15,7 +15,7 @@ namespace Binance
         /// <summary>
         /// When the assets were last updated.
         /// </summary>
-        public static readonly long LastUpdateAt = 1513214269488;
+        public static readonly long LastUpdateAt = 1513636152989;
 
         // Redirect (BCH) Bitcoin Cash (BCC = BitConnect)
         public static readonly Asset BCH = BCC;
@@ -35,6 +35,7 @@ namespace Binance
         public static readonly Asset BQX = new Asset("BQX", 8);
         public static readonly Asset BTC = new Asset("BTC", 8);
         public static readonly Asset BTG = new Asset("BTG", 8);
+        public static readonly Asset BTM = new Asset("BTM", 8);
         public static readonly Asset BTS = new Asset("BTS", 8);
         public static readonly Asset CDT = new Asset("CDT", 8);
         public static readonly Asset CMT = new Asset("CMT", 8);
@@ -44,6 +45,7 @@ namespace Binance
         public static readonly Asset DGD = new Asset("DGD", 8);
         public static readonly Asset DLT = new Asset("DLT", 8);
         public static readonly Asset DNT = new Asset("DNT", 8);
+        public static readonly Asset ELC = new Asset("ELC", 8);
         public static readonly Asset ENG = new Asset("ENG", 8);
         public static readonly Asset ENJ = new Asset("ENJ", 8);
         public static readonly Asset EOS = new Asset("EOS", 8);
@@ -53,15 +55,19 @@ namespace Binance
         public static readonly Asset FUEL = new Asset("FUEL", 8);
         public static readonly Asset FUN = new Asset("FUN", 8);
         public static readonly Asset GAS = new Asset("GAS", 8);
+        public static readonly Asset GTO = new Asset("GTO", 8);
         public static readonly Asset GVT = new Asset("GVT", 8);
         public static readonly Asset GXS = new Asset("GXS", 8);
+        public static readonly Asset HCC = new Asset("HCC", 8);
         public static readonly Asset HSR = new Asset("HSR", 8);
         public static readonly Asset ICN = new Asset("ICN", 8);
+        public static readonly Asset ICX = new Asset("ICX", 8);
         public static readonly Asset IOTA = new Asset("IOTA", 8);
         public static readonly Asset KMD = new Asset("KMD", 8);
         public static readonly Asset KNC = new Asset("KNC", 8);
         public static readonly Asset LEND = new Asset("LEND", 8);
         public static readonly Asset LINK = new Asset("LINK", 8);
+        public static readonly Asset LLT = new Asset("LLT", 8);
         public static readonly Asset LRC = new Asset("LRC", 8);
         public static readonly Asset LSK = new Asset("LSK", 8);
         public static readonly Asset LTC = new Asset("LTC", 8);
@@ -90,12 +96,14 @@ namespace Binance
         public static readonly Asset STORJ = new Asset("STORJ", 8);
         public static readonly Asset STRAT = new Asset("STRAT", 8);
         public static readonly Asset SUB = new Asset("SUB", 8);
+        public static readonly Asset TNB = new Asset("TNB", 8);
         public static readonly Asset TNT = new Asset("TNT", 8);
         public static readonly Asset TRX = new Asset("TRX", 8);
         public static readonly Asset USDT = new Asset("USDT", 8);
         public static readonly Asset VEN = new Asset("VEN", 8);
         public static readonly Asset VIB = new Asset("VIB", 8);
         public static readonly Asset WABI = new Asset("WABI", 8);
+        public static readonly Asset WAVES = new Asset("WAVES", 8);
         public static readonly Asset WTC = new Asset("WTC", 8);
         public static readonly Asset XLM = new Asset("XLM", 8);
         public static readonly Asset XMR = new Asset("XMR", 8);
@@ -149,6 +157,7 @@ namespace Binance
             { "BQX", BQX },
             { "BTC", BTC },
             { "BTG", BTG },
+            { "BTM", BTM },
             { "BTS", BTS },
             { "CDT", CDT },
             { "CMT", CMT },
@@ -158,6 +167,7 @@ namespace Binance
             { "DGD", DGD },
             { "DLT", DLT },
             { "DNT", DNT },
+            { "ELC", ELC },
             { "ENG", ENG },
             { "ENJ", ENJ },
             { "EOS", EOS },
@@ -167,15 +177,19 @@ namespace Binance
             { "FUEL", FUEL },
             { "FUN", FUN },
             { "GAS", GAS },
+            { "GTO", GTO },
             { "GVT", GVT },
             { "GXS", GXS },
+            { "HCC", HCC },
             { "HSR", HSR },
             { "ICN", ICN },
+            { "ICX", ICX },
             { "IOTA", IOTA },
             { "KMD", KMD },
             { "KNC", KNC },
             { "LEND", LEND },
             { "LINK", LINK },
+            { "LLT", LLT },
             { "LRC", LRC },
             { "LSK", LSK },
             { "LTC", LTC },
@@ -204,12 +218,14 @@ namespace Binance
             { "STORJ", STORJ },
             { "STRAT", STRAT },
             { "SUB", SUB },
+            { "TNB", TNB },
             { "TNT", TNT },
             { "TRX", TRX },
             { "USDT", USDT },
             { "VEN", VEN },
             { "VIB", VIB },
             { "WABI", WABI },
+            { "WAVES", WAVES },
             { "WTC", WTC },
             { "XLM", XLM },
             { "XMR", XMR },

--- a/src/Binance/Symbol.cs
+++ b/src/Binance/Symbol.cs
@@ -15,7 +15,7 @@ namespace Binance
         /// <summary>
         /// When the symbols (currency pairs) were last updated.
         /// </summary>
-        public static readonly long LastUpdateAt = 1513214269488;
+        public static readonly long LastUpdateAt = 1513636152989;
 
         // Redirect (BCH) Bitcoin Cash (BCC = BitConnect)
         public static readonly Symbol BCH_USDT = BCC_USDT;
@@ -47,24 +47,30 @@ namespace Binance
         public static readonly Symbol DGD_BTC = new Symbol(Asset.DGD, Asset.BTC, 0.00100000m, 10000000.00000000m, 0.00000100m);
         public static readonly Symbol DLT_BTC = new Symbol(Asset.DLT, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol DNT_BTC = new Symbol(Asset.DNT, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol ELC_BTC = new Symbol(Asset.ELC, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol ENG_BTC = new Symbol(Asset.ENG, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol ENJ_BTC = new Symbol(Asset.ENJ, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol EOS_BTC = new Symbol(Asset.EOS, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol ETC = new Symbol(Asset.ETC, Asset.BTC, 0.00000001m, 100000.00000000m, 0.00000001m, ETC);
         public static readonly Symbol ETC_BTC = new Symbol(Asset.ETC, Asset.BTC, 0.01000000m, 10000000.00000000m, 0.00000100m);
         public static readonly Symbol ETH_BTC = new Symbol(Asset.ETH, Asset.BTC, 0.00100000m, 100000.00000000m, 0.00000100m);
         public static readonly Symbol EVX_BTC = new Symbol(Asset.EVX, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol FUEL_BTC = new Symbol(Asset.FUEL, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol FUN_BTC = new Symbol(Asset.FUN, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol GAS_BTC = new Symbol(Asset.GAS, Asset.BTC, 0.01000000m, 100000.00000000m, 0.00000100m);
+        public static readonly Symbol GTO_BTC = new Symbol(Asset.GTO, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol GVT_BTC = new Symbol(Asset.GVT, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol GXS_BTC = new Symbol(Asset.GXS, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
+        public static readonly Symbol HCC_BTC = new Symbol(Asset.HCC, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol HSR_BTC = new Symbol(Asset.HSR, Asset.BTC, 0.01000000m, 10000000.00000000m, 0.00000100m);
         public static readonly Symbol ICN_BTC = new Symbol(Asset.ICN, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol ICX_BTC = new Symbol(Asset.ICX, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol IOTA_BTC = new Symbol(Asset.IOTA, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol KMD_BTC = new Symbol(Asset.KMD, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol KNC_BTC = new Symbol(Asset.KNC, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol LEND_BTC = new Symbol(Asset.LEND, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol LINK_BTC = new Symbol(Asset.LINK, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol LLT_BTC = new Symbol(Asset.LLT, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol LRC_BTC = new Symbol(Asset.LRC, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol LSK_BTC = new Symbol(Asset.LSK, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol LTC_BTC = new Symbol(Asset.LTC, Asset.BTC, 0.01000000m, 100000.00000000m, 0.00000100m);
@@ -93,11 +99,13 @@ namespace Binance
         public static readonly Symbol STORJ_BTC = new Symbol(Asset.STORJ, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol STRAT_BTC = new Symbol(Asset.STRAT, Asset.BTC, 0.01000000m, 10000000.00000000m, 0.00000100m);
         public static readonly Symbol SUB_BTC = new Symbol(Asset.SUB, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol TNB_BTC = new Symbol(Asset.TNB, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol TNT_BTC = new Symbol(Asset.TNT, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol TRX_BTC = new Symbol(Asset.TRX, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol VEN_BTC = new Symbol(Asset.VEN, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol VIB_BTC = new Symbol(Asset.VIB, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol WABI_BTC = new Symbol(Asset.WABI, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol WAVES_BTC = new Symbol(Asset.WAVES, Asset.BTC, 0.01000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol WTC_BTC = new Symbol(Asset.WTC, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol XLM_BTC = new Symbol(Asset.XLM, Asset.BTC, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol XMR_BTC = new Symbol(Asset.XMR, Asset.BTC, 0.00100000m, 10000000.00000000m, 0.00000100m);
@@ -123,6 +131,7 @@ namespace Binance
         public static readonly Symbol BNT_ETH = new Symbol(Asset.BNT, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol BQX_ETH = new Symbol(Asset.BQX, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol BTG_ETH = new Symbol(Asset.BTG, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
+        public static readonly Symbol BTM_ETH = new Symbol(Asset.BTM, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol BTS_ETH = new Symbol(Asset.BTS, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol CDT_ETH = new Symbol(Asset.CDT, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol CMT_ETH = new Symbol(Asset.CMT, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
@@ -139,10 +148,12 @@ namespace Binance
         public static readonly Symbol EVX_ETH = new Symbol(Asset.EVX, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol FUEL_ETH = new Symbol(Asset.FUEL, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol FUN_ETH = new Symbol(Asset.FUN, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol GTO_ETH = new Symbol(Asset.GTO, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol GVT_ETH = new Symbol(Asset.GVT, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol GXS_ETH = new Symbol(Asset.GXS, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol HSR_ETH = new Symbol(Asset.HSR, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol ICN_ETH = new Symbol(Asset.ICN, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000010m);
+        public static readonly Symbol ICX_ETH = new Symbol(Asset.ICX, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol IOTA_ETH = new Symbol(Asset.IOTA, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol KMD_ETH = new Symbol(Asset.KMD, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol KNC_ETH = new Symbol(Asset.KNC, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000010m);
@@ -176,11 +187,13 @@ namespace Binance
         public static readonly Symbol STORJ_ETH = new Symbol(Asset.STORJ, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000010m);
         public static readonly Symbol STRAT_ETH = new Symbol(Asset.STRAT, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol SUB_ETH = new Symbol(Asset.SUB, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol TNB_ETH = new Symbol(Asset.TNB, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol TNT_ETH = new Symbol(Asset.TNT, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol TRX_ETH = new Symbol(Asset.TRX, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol VEN_ETH = new Symbol(Asset.VEN, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol VIB_ETH = new Symbol(Asset.VIB, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol WABI_ETH = new Symbol(Asset.WABI, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
+        public static readonly Symbol WAVES_ETH = new Symbol(Asset.WAVES, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol WTC_ETH = new Symbol(Asset.WTC, Asset.ETH, 0.01000000m, 90000000.00000000m, 0.00000100m);
         public static readonly Symbol XLM_ETH = new Symbol(Asset.XLM, Asset.ETH, 1.00000000m, 90000000.00000000m, 0.00000001m);
         public static readonly Symbol XMR_ETH = new Symbol(Asset.XMR, Asset.ETH, 0.00100000m, 10000000.00000000m, 0.00001000m);
@@ -201,7 +214,10 @@ namespace Binance
         public static readonly Symbol CMT_BNB = new Symbol(Asset.CMT, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol CND_BNB = new Symbol(Asset.CND, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol DLT_BNB = new Symbol(Asset.DLT, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
+        public static readonly Symbol GTO_BNB = new Symbol(Asset.GTO, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
+        public static readonly Symbol ICX_BNB = new Symbol(Asset.ICX, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol IOTA_BNB = new Symbol(Asset.IOTA, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
+        public static readonly Symbol LEND_BNB = new Symbol(Asset.LEND, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol LSK_BNB = new Symbol(Asset.LSK, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00010000m);
         public static readonly Symbol LTC_BNB = new Symbol(Asset.LTC, Asset.BNB, 0.00001000m, 10000000.00000000m, 0.01000000m);
         public static readonly Symbol NEO_BNB = new Symbol(Asset.NEO, Asset.BNB, 0.00100000m, 10000000.00000000m, 0.00100000m);
@@ -211,7 +227,8 @@ namespace Binance
         public static readonly Symbol RCN_BNB = new Symbol(Asset.RCN, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol RDN_BNB = new Symbol(Asset.RDN, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol VEN_BNB = new Symbol(Asset.VEN, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00010000m);
-        public static readonly Symbol WABI_BNB = new Symbol(Asset.WABI, Asset.BNB, 0.00000001m, 100000.00000000m, 0.00000001m);
+        public static readonly Symbol WABI_BNB = new Symbol(Asset.WABI, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
+        public static readonly Symbol WAVES_BNB = new Symbol(Asset.WAVES, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00010000m);
         public static readonly Symbol WTC_BNB = new Symbol(Asset.WTC, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00010000m);
         public static readonly Symbol XLM_BNB = new Symbol(Asset.XLM, Asset.BNB, 0.01000000m, 10000000.00000000m, 0.00001000m);
         public static readonly Symbol XZC_BNB = new Symbol(Asset.XZC, Asset.BNB, 0.00100000m, 10000000.00000000m, 0.00100000m);
@@ -292,6 +309,7 @@ namespace Binance
             { "BTCUSDT", BTC_USDT },
             { "BTGBTC", BTG_BTC },
             { "BTGETH", BTG_ETH },
+            { "BTMETH", BTM_ETH },
             { "BTSBNB", BTS_BNB },
             { "BTSBTC", BTS_BTC },
             { "BTSETH", BTS_ETH },
@@ -314,12 +332,14 @@ namespace Binance
             { "DLTETH", DLT_ETH },
             { "DNTBTC", DNT_BTC },
             { "DNTETH", DNT_ETH },
+            { "ELCBTC", ELC_BTC },
             { "ENGBTC", ENG_BTC },
             { "ENGETH", ENG_ETH },
             { "ENJBTC", ENJ_BTC },
             { "ENJETH", ENJ_ETH },
             { "EOSBTC", EOS_BTC },
             { "EOSETH", EOS_ETH },
+            { "ETC", ETC},
             { "ETCBTC", ETC_BTC },
             { "ETCETH", ETC_ETH },
             { "ETHBTC", ETH_BTC },
@@ -331,14 +351,21 @@ namespace Binance
             { "FUNBTC", FUN_BTC },
             { "FUNETH", FUN_ETH },
             { "GASBTC", GAS_BTC },
+            { "GTOBNB", GTO_BNB },
+            { "GTOBTC", GTO_BTC },
+            { "GTOETH", GTO_ETH },
             { "GVTBTC", GVT_BTC },
             { "GVTETH", GVT_ETH },
             { "GXSBTC", GXS_BTC },
             { "GXSETH", GXS_ETH },
+            { "HCCBTC", HCC_BTC },
             { "HSRBTC", HSR_BTC },
             { "HSRETH", HSR_ETH },
             { "ICNBTC", ICN_BTC },
             { "ICNETH", ICN_ETH },
+            { "ICXBNB", ICX_BNB },
+            { "ICXBTC", ICX_BTC },
+            { "ICXETH", ICX_ETH },
             { "IOTABNB", IOTA_BNB },
             { "IOTABTC", IOTA_BTC },
             { "IOTAETH", IOTA_ETH },
@@ -346,10 +373,12 @@ namespace Binance
             { "KMDETH", KMD_ETH },
             { "KNCBTC", KNC_BTC },
             { "KNCETH", KNC_ETH },
+            { "LENDBNB", LEND_BNB },
             { "LENDBTC", LEND_BTC },
             { "LENDETH", LEND_ETH },
             { "LINKBTC", LINK_BTC },
             { "LINKETH", LINK_ETH },
+            { "LLTBTC", LLT_BTC },
             { "LRCBTC", LRC_BTC },
             { "LRCETH", LRC_ETH },
             { "LSKBNB", LSK_BNB },
@@ -416,6 +445,8 @@ namespace Binance
             { "STRATETH", STRAT_ETH },
             { "SUBBTC", SUB_BTC },
             { "SUBETH", SUB_ETH },
+            { "TNBBTC", TNB_BTC },
+            { "TNBETH", TNB_ETH },
             { "TNTBTC", TNT_BTC },
             { "TNTETH", TNT_ETH },
             { "TRXBTC", TRX_BTC },
@@ -428,6 +459,9 @@ namespace Binance
             { "WABIBNB", WABI_BNB },
             { "WABIBTC", WABI_BTC },
             { "WABIETH", WABI_ETH },
+            { "WAVESBNB", WAVES_BNB },
+            { "WAVESBTC", WAVES_BTC },
+            { "WAVESETH", WAVES_ETH },
             { "WTCBNB", WTC_BNB },
             { "WTCBTC", WTC_BTC },
             { "WTCETH", WTC_ETH },
@@ -498,7 +532,8 @@ namespace Binance
         /// <param name="baseMaxQty">The base asset maximum quantity.</param>
         /// <param name="baseMinQty">The base asset minimum quantity.</param>
         /// <param name="quoteIncrement">The quote asset increment price.</param>
-        public Symbol(Asset baseAsset, Asset quoteAsset, decimal baseMinQty, decimal baseMaxQty, decimal quoteIncrement)
+        /// <param name="symbolName">Symbol name override if it does not match with concatenated name of base and quote assets.</param>
+        public Symbol(Asset baseAsset, Asset quoteAsset, decimal baseMinQty, decimal baseMaxQty, decimal quoteIncrement, string symbolName = null)
         {
             Throw.IfNull(baseAsset, nameof(baseAsset));
             Throw.IfNull(quoteAsset, nameof(quoteAsset));
@@ -516,7 +551,14 @@ namespace Binance
             BaseMaxQuantity = baseMaxQty;
             QuoteIncrement = quoteIncrement;
 
-            _symbol = $"{baseAsset}{quoteAsset}";
+            if (!String.IsNullOrWhiteSpace(symbolName))
+            {
+                _symbol = symbolName;
+            }
+            else
+            {
+                _symbol = $"{baseAsset}{quoteAsset}";
+            }
         }
 
         #endregion Constructors


### PR DESCRIPTION
- Fix symbol handling, where the symbol name is not a {base}{quote} name concatenation
- Refresh symbols with new set