### PR TITLE
IServiceProvider ObjectDisposedException fix. 

### DIFF
--- a/src/Binance/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Binance/Extensions/ServiceCollectionExtensions.cs
@@ -21,16 +21,12 @@ namespace Binance
             services.AddSingleton<ITimestampProvider, TimestampProvider>();
             services.AddSingleton<IBinanceHttpClient>(s =>
             {
-                if (!BinanceHttpClient.Initializer.IsValueCreated)
-                {
-                    // Replace initializer.
-                    BinanceHttpClient.Initializer = new Lazy<BinanceHttpClient>(() =>
-                        new BinanceHttpClient(
-                            s.GetService<ITimestampProvider>(),
-                            s.GetService<IApiRateLimiter>(),
-                            s.GetService<IOptions<BinanceApiOptions>>(),
-                            s.GetService<ILogger<BinanceHttpClient>>()), true);
-                }
+                BinanceHttpClient.Initializer = new Lazy<BinanceHttpClient>(() =>
+                    new BinanceHttpClient(
+                        s.GetService<ITimestampProvider>(),
+                        s.GetService<IApiRateLimiter>(),
+                        s.GetService<IOptions<BinanceApiOptions>>(),
+                        s.GetService<ILogger<BinanceHttpClient>>()), true);
 
                 return BinanceHttpClient.Instance;
             });

--- a/test/Binance.Tests/Api/BinanceHttpClientTest.cs
+++ b/test/Binance.Tests/Api/BinanceHttpClientTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Binance.Tests.Api
+{
+    public class BinanceHttpClientTest
+    {
+        [Fact]
+        public void ServiceProviderDisposeNoThrows()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddBinance().BuildServiceProvider();
+
+            var httpClient = serviceProvider.GetService<IBinanceHttpClient>();
+
+            //Restart simulation
+            serviceProvider.Dispose();
+
+            var objectDisposedException = false;
+
+            serviceProvider = new ServiceCollection()
+                .AddBinance().BuildServiceProvider();
+
+            var newHttpClient = serviceProvider.GetService<IBinanceHttpClient>();
+
+            try
+            {
+                newHttpClient.RateLimiter.Configure(TimeSpan.FromSeconds(5), 5);
+            }
+            catch (ObjectDisposedException)
+            {
+                objectDisposedException = true;
+            }
+
+            Assert.False(objectDisposedException);
+            Assert.False(newHttpClient.Equals(httpClient));
+        }
+    }
+}


### PR DESCRIPTION
Error occures when app is restarts. BinanceHttpClient.Initializer.IsValueCreate is true, so we dont recreate BinanceHttpClient, but is needed, because the old IServiceProvider (which uses in ApiRateLimiterProvider, RateLimiterProvider) already disposed

.net core 2.1.1